### PR TITLE
Final update for 023 from Webster

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,7 +510,7 @@ NOTES
 
 
         NAME: XS_Inventory.ps1
-        VERSION: 0.022
+        VERSION: 0.023
         AUTHOR: Carl Webster and John Billekens, along with help from Michael B. Smith, Guy Leech, and the XenServer team
         LASTEDIT: August 12, 2023
 

--- a/XS_Inventory_V1_ReadMe.rtf
+++ b/XS_Inventory_V1_ReadMe.rtf
@@ -1,7 +1,7 @@
 {\rtf1\adeflang1025\ansi\ansicpg1252\uc1\adeff0\deff0\stshfdbch31505\stshfloch31506\stshfhich31506\stshfbi0\deflang1033\deflangfe1033\themelang1033\themelangfe0\themelangcs0{\fonttbl{\f0\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f2\fbidi \fmodern\fcharset0\fprq1{\*\panose 02070309020205020404}Courier New;}
 {\f3\fbidi \froman\fcharset2\fprq2{\*\panose 05050102010706020507}Symbol;}{\f10\fbidi \fnil\fcharset2\fprq2{\*\panose 05000000000000000000}Wingdings;}{\f34\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria Math;}
-{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
-{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}
+{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
+{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}
 {\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\flominor\f31504\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\fdbminor\f31505\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhiminor\f31506\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}
 {\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f44\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\f45\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
@@ -110,22 +110,22 @@ Header Char;}{\s23\ql \li0\ri0\nowidctlpar\tqc\tx4680\tqr\tx9360\wrapdefault\faa
 \levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0
 \levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li6480\lin6480 }{\listname ;}\listid1955283310}}{\*\listoverridetable{\listoverride\listid1955283310\listoverridecount0\ls1}{\listoverride\listid1818835589
 \listoverridecount0\ls2}{\listoverride\listid319386001\listoverridecount0\ls3}{\listoverride\listid1259829870\listoverridecount0\ls4}{\listoverride\listid747194388\listoverridecount0\ls5}{\listoverride\listid264927731\listoverridecount0\ls6}
-{\listoverride\listid1694726244\listoverridecount0\ls7}}{\*\pgptbl {\pgp\ipgp0\itap0\li0\ri0\sb0\sa0}}{\*\rsidtbl \rsid219208\rsid677819\rsid995078\rsid1012917\rsid1602598\rsid2579094\rsid2584542\rsid2978753\rsid3344576\rsid3426073\rsid3496162\rsid3678897
-\rsid3761251\rsid3830441\rsid4063807\rsid4412263\rsid4788357\rsid5267713\rsid6041144\rsid6104541\rsid6258287\rsid6520475\rsid8068250\rsid8410782\rsid8478496\rsid9111200\rsid9112866\rsid9467414\rsid9528706\rsid9703780\rsid9729535\rsid9986361\rsid11281155
-\rsid11287022\rsid11480840\rsid11488686\rsid11731749\rsid12013473\rsid12215775\rsid12585615\rsid12801149\rsid13120733\rsid13513834\rsid13593745\rsid13844203\rsid13853169\rsid13987238\rsid14697282\rsid14881286\rsid14966414\rsid15666087\rsid16078565
-\rsid16349588\rsid16395009\rsid16517051\rsid16597410\rsid16673813}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Carl Webster}
-{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2023\mo8\dy12\hr17\min23}{\version37}{\edmins275}{\nofpages18}{\nofwords4596}{\nofchars26201}{\nofcharsws30736}{\vern77}}{\*\userprops {\propname GrammarlyDocumentId}\proptype30{\staticval 3fd2975cd99c5b9cf68
+{\listoverride\listid1694726244\listoverridecount0\ls7}}{\*\pgptbl {\pgp\ipgp0\itap0\li0\ri0\sb0\sa0}}{\*\rsidtbl \rsid219208\rsid677819\rsid995078\rsid1012917\rsid1602598\rsid2181327\rsid2579094\rsid2584542\rsid2978753\rsid3344576\rsid3426073\rsid3496162
+\rsid3678897\rsid3761251\rsid3830441\rsid4063807\rsid4412263\rsid4788357\rsid5267713\rsid6041144\rsid6104541\rsid6258287\rsid6520475\rsid8068250\rsid8410782\rsid8478496\rsid9111200\rsid9112866\rsid9467414\rsid9528706\rsid9703780\rsid9729535\rsid9986361
+\rsid11281155\rsid11287022\rsid11480840\rsid11488686\rsid11696173\rsid11731749\rsid12013473\rsid12215775\rsid12585615\rsid12801149\rsid13120733\rsid13513834\rsid13593745\rsid13844203\rsid13853169\rsid13987238\rsid14697282\rsid14881286\rsid14966414
+\rsid15666087\rsid16078565\rsid16349588\rsid16395009\rsid16517051\rsid16597410\rsid16673813}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Carl Webster}
+{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2023\mo8\dy12\hr17\min39}{\version38}{\edmins275}{\nofpages18}{\nofwords4596}{\nofchars26201}{\nofcharsws30736}{\vern77}}{\*\userprops {\propname GrammarlyDocumentId}\proptype30{\staticval 3fd2975cd99c5b9cf68
 f62fa6d88418f1aab9454bf804457ab26ef3f30daedff}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
 \widowctrl\ftnbj\aenddoc\trackmoves0\trackformatting1\donotembedsysfont0\relyonvml0\donotembedlingdata1\grfdocevents0\validatexml0\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors0\horzdoc\dghspace120\dgvspace120\dghorigin1701
 \dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale100\rsidroot11488686 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
-{\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0MbCwsDA0MzcytjQwNjBS0lEKTi0uzszPAykwMqoFAAojNbstAAAA}}{\*\ftnsep \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid15666087 \rtlch\fcs1 
-\af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid14966414 \chftnsep 
+{\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0MbCwsDA0MzcytjQwNjBS0lEKTi0uzszPAykwMq4FAEsSLqItAAAA}}{\*\ftnsep \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid15666087 \rtlch\fcs1 
+\af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid2181327 \chftnsep 
 \par }}{\*\ftnsepc \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid15666087 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
-\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid14966414 \chftnsepc 
+\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid2181327 \chftnsepc 
 \par }}{\*\aftnsep \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid15666087 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
-\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid14966414 \chftnsep 
+\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid2181327 \chftnsep 
 \par }}{\*\aftnsepc \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid15666087 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
-\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid14966414 \chftnsepc 
+\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid2181327 \chftnsepc 
 \par }}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\headerl \ltrpar \pard\plain \ltrpar\s21\ql \li0\ri0\nowidctlpar\tqc\tx4680\tqr\tx9360\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid15666087 
 \par }}{\headerr \ltrpar \pard\plain \ltrpar\s21\ql \li0\ri0\nowidctlpar\tqc\tx4680\tqr\tx9360\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
@@ -312,7 +312,7 @@ Before using PowerShell to document anything in a Xen}{\rtlch\fcs1 \af37\afs22 \
 {\field\flddirty{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\lang1024\langfe1024\noproof\insrsid12013473\charrsid16349588 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "http://Citrix.com" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\lang1024\langfe1024\noproof\insrsid11731749\charrsid16349588 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b3e00000068007400740070003a002f002f006300690074007200690078002e0063006f006d002f000000795881f43b1d7f48af2c825dc485276300000000a5ab0000000000000050efb1711c023300d0736400480165
-004000c5}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf2\lang1024\langfe1024\noproof\insrsid12013473\charrsid16349588 \hich\af37\dbch\af31505\loch\f37 http://Citrix.com}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 
+004000c5cd}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf2\lang1024\langfe1024\noproof\insrsid12013473\charrsid16349588 \hich\af37\dbch\af31505\loch\f37 http://Citrix.com}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 
 \af37\afs22 \ltrch\fcs0 \f37\fs22\lang1024\langfe1024\noproof\insrsid12013473\charrsid16349588 \hich\af37\dbch\af31505\loch\f37  ,}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12013473 
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f2\fs22\lang1024\langfe1024\noproof\insrsid12013473\charrsid16349588 \hich\af2\dbch\af31505\loch\f2 o\tab}}\pard \ltrpar\ql \fi-360\li1440\ri0\sa200\sl276\slmult1
 \nowidctlpar\wrapdefault\faauto\ls4\ilvl1\rin0\lin1440\itap0\pararsid8478496 {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\lang1024\langfe1024\noproof\insrsid12013473\charrsid16349588 \hich\af37\dbch\af31505\loch\f37 Log}{\rtlch\fcs1 \af37\afs22 
@@ -515,7 +515,7 @@ XS_Inventory.ps1 -ServerName <String> [-User <String>] [-HTML] [-Text] }{\rtlch\
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2      Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -User <String>
 \par \hich\af2\dbch\af31505\loch\f2         Username to use for the connection to the XenServer Pool.
@@ -523,7 +523,7 @@ XS_Inventory.ps1 -ServerName <String> [-User <String>] [-HTML] [-Text] }{\rtlch\
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pip\hich\af2\dbch\af31505\loch\f2 eline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeli\hich\af2\dbch\af31505\loch\f2 ne input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -HTML [<SwitchParameter>]
@@ -531,7 +531,7 @@ XS_Inventory.ps1 -ServerName <String> [-User <String>] [-HTML] [-Text] }{\rtlch\
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         HTML is the default report format.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is set to True   If no other output\hich\af2\dbch\af31505\loch\f2  format is selected.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is set to True   If no other output fo\hich\af2\dbch\af31505\loch\f2 rmat is selected.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -539,7 +539,7 @@ XS_Inventory.ps1 -ServerName <String> [-User <String>] [-HTML] [-Text] }{\rtlch\
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -Text [<Switch\hich\af2\dbch\af31505\loch\f2 Parameter>]
+\par \hich\af2\dbch\af31505\loch\f2     -Text [<SwitchPar\hich\af2\dbch\af31505\loch\f2 ameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Creates a formatted text file with a .txt extension.
 \par \hich\af2\dbch\af31505\loch\f2         Text formatting is based on the default tab spacing of 8 by Microsoft Notepad.
 \par 
@@ -819,21 +819,21 @@ XS_Inventory.ps1 -ServerName <String> [-User <String>] [-HTML] [-Text] }{\rtlch\
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline\hich\af2\dbch\af31505\loch\f2  input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -CoverPage <\hich\af2\dbch\af31505\loch\f2 String>
+\par \hich\af2\dbch\af31505\loch\f2     -CoverPage <String>
 \par \hich\af2\dbch\af31505\loch\f2         What Microsoft Word Cover Page to use.
 \par \hich\af2\dbch\af31505\loch\f2         Only Word 2010, 2013, and 2016 are supported.
 \par \hich\af2\dbch\af31505\loch\f2         (default cover pages in Word en-US)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Valid input is:
+\par \hich\af2\dbch\af31505\loch\f2         Valid input is\hich\af2\dbch\af31505\loch\f2 :
 \par \hich\af2\dbch\af31505\loch\f2                 Alphabet (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Annual (Word 2010.\hich\af2\dbch\af31505\loch\f2  Doesn't work well for this report)
+\par \hich\af2\dbch\af31505\loch\f2                 Annual (Word 2010. Doesn't work well for this report)
 \par \hich\af2\dbch\af31505\loch\f2                 Austere (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Austin (Word 2010/2013/2016. Doesn't work in 2013 or 2016, mostly
-\par \hich\af2\dbch\af31505\loch\f2                 works in 2010, but Subtitle/Subject & Author fields need moving
-\par \hich\af2\dbch\af31505\loch\f2                \hich\af2\dbch\af31505\loch\f2  after the title box is moved up)
+\par \hich\af2\dbch\af31505\loch\f2                \hich\af2\dbch\af31505\loch\f2  works in 2010, but Subtitle/Subject & Author fields need moving
+\par \hich\af2\dbch\af31505\loch\f2                 after the title box is moved up)
 \par \hich\af2\dbch\af31505\loch\f2                 Banded (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Conservative (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010. Works)
@@ -949,7 +949,7 @@ XS_Inventory.ps1 -ServerName <String> [-User <String>] [-HTML] [-Text] }{\rtlch\
 \par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (}{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9528706 \hich\af2\dbch\af31505\loch\f2 HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"}{\rtlch\fcs1 
 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9528706 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b76000000680074007400700073003a002f002f0067006f002e006d006900630072006f0073006f00660074002e0063006f006d002f00660077006c0069006e006b002f003f004c0069006e006b00490044003d003100
-310033003200310036000000795881f43b1d7f48af2c825dc485276300000000a5ab000300000000}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid9528706\charrsid9528706 \hich\af2\dbch\af31505\loch\f2 
+310033003200310036000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000000000}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid9528706\charrsid9528706 \hich\af2\dbch\af31505\loch\f2 
 https:/go.microsoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9528706\charrsid9528706 \hich\af2\dbch\af31505\loch\f2 ).
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 INPUTS
@@ -965,7 +965,7 @@ https:/go.microsoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefau
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         NAME: XS_Inventory.ps1
-\par \hich\af2\dbch\af31505\loch\f2         VERSION: 0.0}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13513834 \hich\af2\dbch\af31505\loch\f2 2}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16078565 \hich\af2\dbch\af31505\loch\f2 2}{\rtlch\fcs1 
+\par \hich\af2\dbch\af31505\loch\f2         VERSION: 0.0}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13513834 \hich\af2\dbch\af31505\loch\f2 2}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11696173 \hich\af2\dbch\af31505\loch\f2 3}{\rtlch\fcs1 
 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9528706\charrsid9528706 
 \par \hich\af2\dbch\af31505\loch\f2         AUTHOR: Carl Webster and John Billekens}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13513834 ,}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9528706\charrsid9528706 \hich\af2\dbch\af31505\loch\f2 
  along with help from Michael B. Smith, Gu\hich\af2\dbch\af31505\loch\f2 y Leech, and the XenServer team
@@ -977,7 +977,7 @@ https:/go.microsoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefau
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XS_Inventory.ps1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Outputs, by default, to HTML.
-\par \hich\af2\dbch\af31505\loch\f2     Prompts for the XenServer Pool and login cre\hich\af2\dbch\af31505\loch\f2 dentials.
+\par \hich\af2\dbch\af31505\loch\f2     Prompts for the XenServer Pool and login c\hich\af2\dbch\af31505\loch\f2 redentials.
 \par 
 \par 
 \par 
@@ -988,7 +988,7 @@ https:/go.microsoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefau
 \par \hich\af2\dbch\af31505\loch\f2     Consulting" -CoverPage "Mod" -UserName "Carl Webster" -ServerName XS01
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Uses:
-\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  Carl Webster Consulting for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2      \hich\af2\dbch\af31505\loch\f2    Carl Webster Consulting for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2         XenServer host named XS01 for the ServerName.
@@ -1044,7 +1044,7 @@ https:/go.microsoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefau
 \par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9528706 \hich\af2\dbch\af31505\loch\f2 HYPERLINK "mailto:}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9528706\charrsid9528706 
 \hich\af2\dbch\af31505\loch\f2 SuperSleuth@SherlockHolmes.com}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9528706 \hich\af2\dbch\af31505\loch\f2 "}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13513834 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b640000006d00610069006c0074006f003a005300750070006500720053006c006500750074006800400053006800650072006c006f0063006b0048006f006c006d00650073002e0063006f006d000000795881f43b1d
-7f48af2c825dc485276300000000a5ab00030fddae}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid9528706\charrsid9111200 \hich\af2\dbch\af31505\loch\f2 SuperSleuth@SherlockHolmes.com}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
+7f48af2c825dc485276300000000a5ab00030fddae00}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid9528706\charrsid9111200 \hich\af2\dbch\af31505\loch\f2 SuperSleuth@SherlockHolmes.com}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
 \rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9528706 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9528706\charrsid9528706 \hich\af2\dbch\af31505\loch\f2 -PDF
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Uses:
@@ -1092,9 +1092,9 @@ https:/go.microsoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefau
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 8 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XS_Inventory.ps1 -ServerName PoolMaster.domain.com -Section Pool
-\par \hich\af2\dbch\af31505\loch\f2     -NoPoolMemory -NoPoolStorage -NoPoolNetworking
+\par \hich\af2\dbch\af31505\loch\f2     -NoPoolMemory -NoPoolStorage -NoPo\hich\af2\dbch\af31505\loch\f2 olNetworking
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report that contains only Po\hich\af2\dbch\af31505\loch\f2 ol information but with no Memory, Storage, }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9528706 
+\par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report that contains only Pool information but with no Memory, Storage, }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9528706 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9528706\charrsid9528706 \hich\af2\dbch\af31505\loch\f2 or Networking data.}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9528706 
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9528706\charrsid9528706 
 \par \hich\af2\dbch\af31505\loch\f2     Processes only the Pool section of the report.
@@ -1103,9 +1103,9 @@ https:/go.microsoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefau
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 9 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------\hich\af2\dbch\af31505\loch\f2 ------------------- EXAMPLE 9 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2 PS C:\\PSScript >.\\XS_Inventory.ps1 -Section Pool, Host
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XS_Inventory.ps1 -Section Pool, Host
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
 \par 
@@ -1120,13 +1120,13 @@ https:/go.microsoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefau
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XS_Inventory.ps1 -SmtpServer mail.domain.tld -From
 \par \hich\af2\dbch\af31505\loch\f2     XSAdmin@domain.tld -To ITGroup@domain.tld -Text
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script uses the email server mail.domain.tld, sendin\hich\af2\dbch\af31505\loch\f2 g from XSAdmin@domain.tld
+\par \hich\af2\dbch\af31505\loch\f2     The script uses the email server mail.domain.tld, sending from XSAdmin@domain.tld
 \par \hich\af2\dbch\af31505\loch\f2     and sending to ITGroup@domain.tld.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script uses the default SMTP port 25 and does not use SSL.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send an email, the script prompts
-\par \hich\af2\dbch\af31505\loch\f2     the user to enter valid crede\hich\af2\dbch\af31505\loch\f2 ntials.
+\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send \hich\af2\dbch\af31505\loch\f2 an email, the script prompts
+\par \hich\af2\dbch\af31505\loch\f2     the user to enter valid credentials.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Outputs to a text file.
 \par \hich\af2\dbch\af31505\loch\f2     Prompts for the XenServer Pool and login credentials.
@@ -1136,8 +1136,8 @@ https:/go.microsoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefau
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 11 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XS_Inventory.ps1 -SmtpServer mailrelay.domain.tld -From
-\par \hich\af2\dbch\af31505\loch\f2     Anony\hich\af2\dbch\af31505\loch\f2 mous@domain.tld -To ITGroup@domain.tld
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XS_\hich\af2\dbch\af31505\loch\f2 Inventory.ps1 -SmtpServer mailrelay.domain.tld -From
+\par \hich\af2\dbch\af31505\loch\f2     Anonymous@domain.tld -To ITGroup@domain.tld
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ***SENDING UNAUTHENTICATED EMAIL***
 \par 
@@ -1145,32 +1145,32 @@ https:/go.microsoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefau
 \par \hich\af2\dbch\af31505\loch\f2     anonymous@domain.tld and sending to ITGroup@domain.tld.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     To send an unauthenticated email using an email relay server requires the From email
-\par \hich\af2\dbch\af31505\loch\f2     account to use the name Anonymous.
+\par \hich\af2\dbch\af31505\loch\f2     account to use the name Anonym\hich\af2\dbch\af31505\loch\f2 ous.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script uses the default SMTP port 25 and does not use SSL.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ***GMAIL/G SUITE SMTP RELAY***
-\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9528706 \hich\af2\dbch\af31505\loch\f2 HYPERLINK "https://s\hich\af2\dbch\af31505\loch\f2 upport.google.com/a/answer/2956491?hl=en"}{\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9528706 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9528706 \hich\af2\dbch\af31505\loch\f2 HYPERLINK "https://support.google.com/a/answer/2956491?hl=en"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid9528706 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7c000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0032003900350036003400
-390031003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab0003d90098f9}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid9528706\charrsid9528706 \hich\af2\dbch\af31505\loch\f2 
+390031003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab0003d90098f900}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid9528706\charrsid9528706 \hich\af2\dbch\af31505\loch\f2 
 https://support.google.com/a/answer/2956491?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9528706\charrsid9528706 
-\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9528706 \hich\af2\dbch\af31505\loch\f2 HYPERLINK "https://support.google.c\hich\af2\dbch\af31505\loch\f2 om/a/answer/176600?hl=en"}{\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9528706 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9528706 \hich\af2\dbch\af31505\loch\f2 HYPERLINK "https://support.google.com/a/answer/176600?hl=en"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid9528706 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7a000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0031003700360036003000
-30003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab00030061c000}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid9528706\charrsid9528706 \hich\af2\dbch\af31505\loch\f2 
+30003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab00030061c00000}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid9528706\charrsid9528706 \hich\af2\dbch\af31505\loch\f2 
 https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9528706\charrsid9528706 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     To send an email using a Gmail or }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9528706 \hich\af2\dbch\af31505\loch\f2 G-suite}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9528706\charrsid9528706 
-\hich\af2\dbch\af31505\loch\f2  account, y\hich\af2\dbch\af31505\loch\f2 ou may have to turn ON the "Less
+\hich\af2\dbch\af31505\loch\f2  account, you may have to turn ON the "Less
 \par \hich\af2\dbch\af31505\loch\f2     secure app access" option on your account.
 \par \hich\af2\dbch\af31505\loch\f2     ***GMAIL/G SUITE SMTP RELAY***
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script generates an anonymous, secure password for the anonymous@domain.tld
+\par \hich\af2\dbch\af31505\loch\f2     The \hich\af2\dbch\af31505\loch\f2 script generates an anonymous, secure password for the anonymous@domain.tld
 \par \hich\af2\dbch\af31505\loch\f2     account.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Outputs, by default, to HTML.
-\par \hich\af2\dbch\af31505\loch\f2     Prom\hich\af2\dbch\af31505\loch\f2 pts for the XenServer Pool and login credentials.
+\par \hich\af2\dbch\af31505\loch\f2     Prompts for the XenServer Pool and login credentials.
 \par 
 \par 
 \par 
@@ -1182,25 +1182,25 @@ https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\sectde
 \par \hich\af2\dbch\af31505\loch\f2     SomeEmailAddress@labaddomain.com -To ITGroupDL@labaddomain.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ***OFFICE 365 Example***
-\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9528706 \hich\af2\dbch\af31505\loch\f2 HYPERLINK "https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a
-\hich\af2\dbch\af31505\loch\f2 -multifunction-device-or-application-to-send-email-using-office-3"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9528706 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9528706 \hich\af2\dbch\af31505\loch\f2 HYPERLINK "https://docs.microsoft.com/en-u\hich\af2\dbch\af31505\loch\f2 
+s/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-office-3"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9528706 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b40010000680074007400700073003a002f002f0064006f00630073002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f00650078006300680061006e0067006500
 2f006d00610069006c002d0066006c006f0077002d0062006500730074002d007000720061006300740069006300650073002f0068006f0077002d0074006f002d007300650074002d00750070002d0061002d006d0075006c0074006900660075006e006300740069006f006e002d006400650076006900630065002d006f
-0072002d006100700070006c00690063006100740069006f006e002d0074006f002d00730065006e0064002d0065006d00610069006c002d007500730069006e0067002d006f00660066006900630065002d0033000000795881f43b1d7f48af2c825dc485276300000000a5ab00037f0000d0}}}{\fldrslt {
+0072002d006100700070006c00690063006100740069006f006e002d0074006f002d00730065006e0064002d0065006d00610069006c002d007500730069006e0067002d006f00660066006900630065002d0033000000795881f43b1d7f48af2c825dc485276300000000a5ab00037f0000d0a5}}}{\fldrslt {
 \rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid9528706\charrsid9528706 \hich\af2\dbch\af31505\loch\f2 
 https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-office-3}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid9528706\charrsid9528706 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     This uses Option 2 from the above link.
+\par \hich\af2\dbch\af31505\loch\f2     This uses Option 2\hich\af2\dbch\af31505\loch\f2  from the above link.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ***OFFICE 365 Example***
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script uses the email server labaddomain-com.mail.protection.outlook.com, sending
 \par \hich\af2\dbch\af31505\loch\f2     from SomeEmailAddress@labaddomain.com and sending to ITGroupDL@labaddomain.com.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script uses the default SMTP port 25 and SSL.
+\par \hich\af2\dbch\af31505\loch\f2     The script uses the defa\hich\af2\dbch\af31505\loch\f2 ult SMTP port 25 and SSL.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Outputs, by default, \hich\af2\dbch\af31505\loch\f2 to HTML.
+\par \hich\af2\dbch\af31505\loch\f2     Outputs, by default, to HTML.
 \par \hich\af2\dbch\af31505\loch\f2     Prompts for the XenServer Pool and login credentials.
 \par 
 \par 
@@ -1208,13 +1208,13 @@ https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 13 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XS_Inventory.ps1 -SmtpServer smtp.office365.com -SmtpPort 587
-\par \hich\af2\dbch\af31505\loch\f2     -UseSSL -From Webster@CarlW\hich\af2\dbch\af31505\loch\f2 ebster.com -To ITGroup@CarlWebster.com
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XS_Inventory.ps1 -SmtpServer smtp.office3\hich\af2\dbch\af31505\loch\f2 65.com -SmtpPort 587
+\par \hich\af2\dbch\af31505\loch\f2     -UseSSL -From Webster@CarlWebster.com -To ITGroup@CarlWebster.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script uses the email server smtp.office365.com on port 587 using SSL, sending from
 \par \hich\af2\dbch\af31505\loch\f2     webster@carlwebster.com and sending to ITGroup@carlwebster.com.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     If the current user'\hich\af2\dbch\af31505\loch\f2 s credentials are not valid to send an email, the script prompts
+\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send an email, the script prompts
 \par \hich\af2\dbch\af31505\loch\f2     the user to enter valid credentials.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Outputs, by default, to HTML.
@@ -1223,20 +1223,20 @@ https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 14 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------\hich\af2\dbch\af31505\loch\f2 - EXAMPLE 14 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XS_Inventory.ps1 -SmtpServer smtp.gmail.com -SmtpPort 587
 \par \hich\af2\dbch\af31505\loch\f2     -UseSSL -From Webster@CarlWebster.com -To ITGroup@CarlWebster.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     *** NOTE ***
-\par \hich\af2\dbch\af31505\loch\f2     To send an email using a Gmail or G-suite account, you may have to \hich\af2\dbch\af31505\loch\f2 turn ON the "Less
+\par \hich\af2\dbch\af31505\loch\f2     To send an email using a Gmail or G-suite a\hich\af2\dbch\af31505\loch\f2 ccount, you may have to turn ON the "Less
 \par \hich\af2\dbch\af31505\loch\f2     secure app access" option on your account.
 \par \hich\af2\dbch\af31505\loch\f2     *** NOTE ***
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script uses the email server smtp.gmail.com on port 587 using SSL, sending from
 \par \hich\af2\dbch\af31505\loch\f2     webster@gmail.com and sending to ITGroup@carlwebster.com.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     If the current use\hich\af2\dbch\af31505\loch\f2 r's credentials are not valid to send an email, the script prompts
+\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send an email, the script prompts
 \par \hich\af2\dbch\af31505\loch\f2     the user to enter valid credentials.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Outputs, by default, to HTML.
@@ -1362,8 +1362,8 @@ fffffffffffffffffdfffffffeffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e50000000000000000000000007066
-44a86bcdd901feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
+ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e50000000000000000000000005021
+1eeb6dcdd901feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000
 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff000000000000000000000000000000000000000000000000
 0000000000000000000000000000000000000000000000000105000000000000}}


### PR DESCRIPTION
#.023
#	Added the following Functions (Webster)
#		OutputPoolWLBSettingsOptimizationMode
#		OutputPoolWLBSettingsAutomation
#		OutputPoolWLBSettingsCriticalThresholds
#		OutputPoolWLBSettingsMetricWeighting
#		OutputPoolWLBSettingsExcludedHosts
#		OutputPoolWLBSettingsAdvanced
#	Fixed handling an invalid option used for -Section (Webster) #	Fixed where there were no Custom Fields or Custom Fields were empty and were not handled properly (Webster) #	Fixed alignment, formatting, and spacing issues for Line and Word/PDF output(Webster) #	Fixed Tags and Folders missing in HTML output (Webster) #	In Function OutputVM, worked around two issues: (Webster) #		A divide by zero error when a key didn't exist: $vm.platform["cores-per-socket"] #		A "null value passed to a method" error when a key didn't exist: $VM.HVM_boot_params['firmware'] #	In Function OutputVMCPU, worked around a divide by zero error when a key didn't exist: $vm.platform["cores-per-socket"] (Webster) #	In Functions OutputHostUpdates and OutputPoolUpdates, change HTML output to not use a fixed width column (Webster) #	Updated the output section headings in Function OutputPoolWLB (Webster)