### PR TITLE
Final update 025 from Webster

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,9 +510,9 @@ NOTES
 
 
         NAME: XS_Inventory.ps1
-        VERSION: 0.024
+        VERSION: 0.025
         AUTHOR: Carl Webster and John Billekens, along with help from Michael B. Smith, Guy Leech, and the XenServer team
-        LASTEDIT: August 15, 2023
+        LASTEDIT: August 20, 2023
 
     -------------------------- EXAMPLE 1 --------------------------
 

--- a/XS_Inventory.ps1
+++ b/XS_Inventory.ps1
@@ -463,9 +463,9 @@
 	text document.
 .NOTES
 	NAME: XS_Inventory.ps1
-	VERSION: 0.024
+	VERSION: 0.025
 	AUTHOR: Carl Webster and John Billekens along with help from Michael B. Smith, Guy Leech, and the XenServer team
-	LASTEDIT: August 15, 2023
+	LASTEDIT: August 20, 2023
 #>
 
 #endregion
@@ -588,6 +588,21 @@ Param(
 #@carlwebster on Twitter
 #http://www.CarlWebster.com
 #Created on June 27, 2023
+#
+#.025
+#	Added some missing section headings in the host output
+#	Copied Function OutputVM to OutputVMGeneralOverview
+#		Altered Function OutputVMGeneralOverview data to match VM General Properties, General
+#	Copied Function OutputVMBootOptions to OutputVMGeneralBootOptions
+#		Altered Function OutputVMGeneralBootOptions data to match VM General Properties, Boot Options
+#	Copied Function OutputVMCPU to OutputVMGeneralCPU
+#		Altered Function OutputVMGeneralCPU data to match VM General Properties, CPUs
+#	Create stub holder Function OutputVMGeneralReadCaching
+#	Fixed the report title for Word/PDF output
+#	For Pool, Host, and VM General output headings, add "General (Overview)" and "General (Properties)"
+#	
+#	Renamed Function OutputVM to OutputVMGeneral
+#	Reordered the VM functions to match the output order in the console
 #
 #.024
 #	In Function ProcessScriptSetup, add getting Workload Balancing data (Webster)
@@ -952,9 +967,9 @@ $ErrorActionPreference = 'SilentlyContinue'
 $Error.Clear()
 
 $Script:emailCredentials = $Null
-$script:MyVersion = '0.024'
+$script:MyVersion = '0.025'
 $Script:ScriptName = "XS_Inventory.ps1"
-$tmpdate = [datetime] "08/15/2023"
+$tmpdate = [datetime] "08/20/2023"
 $Script:ReleaseDate = $tmpdate.ToUniversalTime().ToShortDateString()
 
 If ($MSWord -eq $False -and $PDF -eq $False -and $Text -eq $False -and $HTML -eq $False)
@@ -4343,22 +4358,22 @@ Function ProcessScriptSetup
 	#support multiple section items
 	If ($Section.Count -eq 1 -and $Section -eq "All")
 	{
-		[string]$Script:Title = "Citrix XenServer Inventory"
+		[string]$Script:Title = "Citrix XenServer Inventory for the Pool: $($Script:XSPool.name_label)"
 	}
 	ElseIf ($Section.Count -eq 1)
 	{
 		Switch ($Section)
 		{
-			"Pool"		{ [string]$Script:Title = "Citrix XenServer Inventory (Pool Only)"; Break }
-			"SharedStorage"	{ [string]$Script:Title = "Citrix XenServer Inventory (Shared Storage Only)"; Break }
-			"Host"		{ [string]$Script:Title = "Citrix XenServer Inventory (Hosts Only)"; Break }
-			"VM"		{ [string]$Script:Title = "Citrix XenServer Inventory (VMs Only"; Break }
-			Default		{ [string]$Script:Title = "Citrix XenServer Inventory (Missing a section title for $Section"; Break }
+			"Pool"		{ [string]$Script:Title = "Citrix XenServer Inventory for the Pool: $($Script:XSPool.name_label) (Pool Only)"; Break }
+			"SharedStorage"	{ [string]$Script:Title = "Citrix XenServer Inventory for the Pool: $($Script:XSPool.name_label) (Shared Storage Only)"; Break }
+			"Host"		{ [string]$Script:Title = "Citrix XenServer Inventory for the Pool: $($Script:XSPool.name_label) (Hosts Only)"; Break }
+			"VM"		{ [string]$Script:Title = "Citrix XenServer Inventory for the Pool: $($Script:XSPool.name_label) (VMs Only"; Break }
+			Default		{ [string]$Script:Title = "Citrix XenServer Inventory for the Pool: $($Script:XSPool.name_label) (Missing a section title for $Section"; Break }
 		}
 	}
 	ElseIf ($Section.Count -gt 1)
 	{
-		[string]$Script:Title = "Citrix XenServer Inventory ("
+		[string]$Script:Title = "Citrix XenServer Inventory for the Pool: $($Script:XSPool.name_label) ("
 		Switch ($Section)
 		{
 			"Pool"		{ [string]$Script:Title += "Pool " }
@@ -5357,7 +5372,7 @@ Function OutputPoolGeneralOverview
 
 	If ($MSWord -or $PDF)
 	{
-		WriteWordLine 2 0 "General Overview"
+		WriteWordLine 2 0 "General (Overview)"
 		[System.Collections.Hashtable[]] $ScriptInformation = @()
 		$ScriptInformation += @{ Data = "Pool name"; Value = $Script:XSPool.name_label; }
 		$ScriptInformation += @{ Data = "Description"; Value = $Script:XSPool.name_description; }
@@ -5387,7 +5402,7 @@ Function OutputPoolGeneralOverview
 	}
 	If ($Text)
 	{
-		Line 1 "General Overview"
+		Line 1 "General (Overview)"
 		Line 2 "Pool name`t`t: " $Script:XSPool.name_label
 		Line 2 "Description`t`t: " $Script:XSPool.name_description
 		Line 2 "Tags`t`t`t: " $($xtags -join ", ")
@@ -5402,7 +5417,7 @@ Function OutputPoolGeneralOverview
 		#for HTML output, remove the < and > from <None> xtags and foldername if they are there
 		$xtags = $xtags.Trim("<", ">")
 		$folderName = $folderName.Trim("<", ">")
-		WriteHTMLLine 2 0 "General Overview"
+		WriteHTMLLine 2 0 "General (Overview)"
 		$rowdata = @()
 		$columnHeaders = @("Pool name", ($htmlsilver -bor $htmlbold), $Script:XSPool.name_label, $htmlwhite)
 		$rowdata += @(, ('Description', ($htmlsilver -bor $htmlbold), $Script:XSPool.name_description, $htmlwhite))
@@ -5722,7 +5737,7 @@ Function OutputPoolGeneral
 
 	If ($MSWord -or $PDF)
 	{
-		WriteWordLine 2 0 "General"
+		WriteWordLine 2 0 "General (Properties)"
 		[System.Collections.Hashtable[]] $ScriptInformation = @()
 		$ScriptInformation += @{ Data = "Name"; Value = $Script:XSPool.name_label; }
 		$ScriptInformation += @{ Data = "Description"; Value = $Script:XSPool.name_description; }
@@ -5748,7 +5763,7 @@ Function OutputPoolGeneral
 	}
 	If ($Text)
 	{
-		Line 1 "General"
+		Line 1 "General (Properties)"
 		Line 2 "Name       : " $Script:XSPool.name_label
 		Line 2 "Description: " $Script:XSPool.name_description
 		Line 2 "Folder     : " $folderName
@@ -5760,7 +5775,7 @@ Function OutputPoolGeneral
 		#for HTML output, remove the < and > from <None> xtags and foldername if they are there
 		$xtags = $xtags.Trim("<", ">")
 		$folderName = $folderName.Trim("<", ">")
-		WriteHTMLLine 2 0 "General"
+		WriteHTMLLine 2 0 "General (Properties)"
 		$rowdata = @()
 		$columnHeaders = @("Name", ($htmlsilver -bor $htmlbold), $Script:XSPool.name_label, $htmlwhite)
 		$rowdata += @(, ('Description', ($htmlsilver -bor $htmlbold), $Script:XSPool.name_description, $htmlwhite))
@@ -8845,13 +8860,14 @@ Function OutputHostGeneralOverview
 		$AgentUptime.Hours,
 		$AgentUptime.Minutes)
 
-	If ([String]::IsNullOrEmpty($($XSHost.Other_Config["folder"])))
+	#If ([String]::IsNullOrEmpty($($XSHost.Other_Config["folder"])))
+	If($XSHost.Other_Config.Keys -contains "folder") #added by Webster
 	{
-		$folderName = "<None>"
+		$folderName = $XSHost.Other_Config["folder"]
 	}
 	Else
 	{
-		$folderName = $XSHost.Other_Config["folder"]
+		$folderName = "<None>"
 	}
 
 	If ($XSHost.name_description -eq "Default install")
@@ -8881,6 +8897,7 @@ Function OutputHostGeneralOverview
 		}
 		
 		WriteWordLine 2 0 "Host: $($XSHost.name_label)"
+		WriteWordLIne 3 0 "General (Overview)"
 		[System.Collections.Hashtable[]] $ScriptInformation = @()
 		$ScriptInformation += @{ Data = "Name"; Value = $XSHost.name_label; }
 		$ScriptInformation += @{ Data = "Description"; Value = $XSHostDescription; }
@@ -8916,17 +8933,18 @@ Function OutputHostGeneralOverview
 	If ($Text)
 	{
 		Line 1 "Name: " "$($XSHost.name_label)"
-		Line 2 "Description`t`t: " $XSHostDescription
-		Line 2 "Tags`t`t`t: " "$($xtags -join ", ")"
-		Line 2 "Folder`t`t`t: " $folderName
-		Line 2 "Pool master`t`t: " $IAmThePoolMaster
-		Line 2 "Enabled`t`t`t: " $XSHostenabled
-		Line 2 "iSCSI IQN`t`t: " $XSHost.iscsi_iqn
-		Line 2 "Log destination`t`t: " $LogLocation
-		Line 2 "Server uptime`t`t: " $ServerUptimeString
-		Line 2 "Toolstack uptime`t: " $AgentUptimeString
-		Line 2 "Domain`t`t`t: " $XSHost.external_auth_service_name
-		Line 2 "UUID`t`t`t: " $XSHost.uuid
+		Line 2 "General (Overview)"
+		Line 3 "Description`t`t: " $XSHostDescription
+		Line 3 "Tags`t`t`t: " "$($xtags -join ", ")"
+		Line 3 "Folder`t`t`t: " $folderName
+		Line 3 "Pool master`t`t: " $IAmThePoolMaster
+		Line 3 "Enabled`t`t`t: " $XSHostenabled
+		Line 3 "iSCSI IQN`t`t: " $XSHost.iscsi_iqn
+		Line 3 "Log destination`t`t: " $LogLocation
+		Line 3 "Server uptime`t`t: " $ServerUptimeString
+		Line 3 "Toolstack uptime`t: " $AgentUptimeString
+		Line 3 "Domain`t`t`t: " $XSHost.external_auth_service_name
+		Line 3 "UUID`t`t`t: " $XSHost.uuid
 		Line 0 ""
 	}
 	If ($HTML)
@@ -8935,6 +8953,7 @@ Function OutputHostGeneralOverview
 		$xtags = $xtags.Trim("<", ">")
 		$folderName = $folderName.Trim("<", ">")
 		WriteHTMLLine 2 0 "Host: $($XSHost.name_label)"
+		WriteHTMLLine 3 0 "General (Overview)"
 		$rowdata = @()
 		$columnHeaders = @("Name", ($htmlsilver -bor $htmlbold), $XSHost.name_label, $htmlwhite)
 		$rowdata += @(, ('Description', ($htmlsilver -bor $htmlbold), $XSHostDescription, $htmlwhite))
@@ -9545,7 +9564,7 @@ Function OutputHostGeneral
 	
 	If ($MSWord -or $PDF)
 	{
-		WriteWordLine 3 0 "General"
+		WriteWordLine 3 0 "General (Properties)"
 		[System.Collections.Hashtable[]] $ScriptInformation = @()
 		$ScriptInformation += @{ Data = "Name"; Value = $XSHost.name_label; }
 		$ScriptInformation += @{ Data = "Description"; Value = $XSHostDescription; }
@@ -9573,7 +9592,7 @@ Function OutputHostGeneral
 	}
 	If ($Text)
 	{
-		Line 2 "General"
+		Line 2 "General (Properties)"
 		Line 3 "Description`t`t: " $XSHostDescription
 		Line 3 "Folder`t`t`t: " $folderName
 		Line 3 "Tags`t`t`t: " "$($xtags -join ", ")"
@@ -9585,7 +9604,7 @@ Function OutputHostGeneral
 		#for HTML output, remove the < and > from <None> xtags and foldername if they are there
 		$xtags = $xtags.Trim("<", ">")
 		$folderName = $folderName.Trim("<", ">")
-		WriteHTMLLine 3 0 "General"
+		WriteHTMLLine 3 0 "General (Properties)"
 		$rowdata = @()
 		$columnHeaders = @("Name", ($htmlsilver -bor $htmlbold), $XSHost.name_label, $htmlwhite)
 		$rowdata += @(, ('Description', ($htmlsilver -bor $htmlbold), $XSHostDescription, $htmlwhite))
@@ -12217,7 +12236,6 @@ Function OutputSharedStorageStatus
 		WriteHTMLLine 0 0 ""
 	}
 }
-
 #endregion SharedStorage
 
 #region VMs
@@ -12288,15 +12306,19 @@ Function ProcessVMs
 				$VMHost = "N/A"
 			}
 		}#>
-		OutputVM $VM $VMOSName $VMHost $VMFirst
+		OutputVMGeneralOverview $VM $VMOSName $VMHost $VMFirst
+		OutputVMGeneralBootOptions $VM
+		OutputVMGeneralCPU $VM
+		OutputVMGeneralReadCaching $VM
+		OutputVMGeneral $VM $VMOSName $VMHost $VMFirst
 		OutputVMCustomFields $VM
 		OutputVMCPU $VM
 		OutputVMBootOptions $VM
 		OutputVMStartOptions $VM
 		OutputVMAlerts $VM
+		OutputVMHomeServer $VM
 		OutputVMGPU $VM
 		OutputVMAdvancedOptions $VM
-		OutputVMHomeServer $VM
 		OutputVMStorage $VM $VMHost
 		OutputVMNIC $VM
 		OutputVMSnapshots $VM
@@ -12304,12 +12326,375 @@ Function ProcessVMs
 	}
 }
 
-Function OutputVM
+Function OutputVMGeneralOverview
+{
+	Param([object]$VM, [string]$VMOSName, [string]$VMHost, [bool]$VMFirst)
+	
+	Write-Verbose "$(Get-Date -Format G): `t`tOutput VM General Overview"
+	If ($VMOSName -ne "Unknown")
+	{
+		#remove the pipe symbol from the $VMOSName variable
+		$pos = -1
+		$pos = $VMOSName.IndexOf('|')
+		If ($pos -gt -1)
+		{
+			$VMOSName = $VMOSName.SubString(0, $pos)
+		}
+	}
+
+	[array]$xtags = @()
+	ForEach ($tag in $VM.tags)
+	{
+		$xtags += $tag
+	}
+	If ($xtags.count -gt 0)
+	{
+		[array]$xtags = $xtags | Sort-Object
+	}
+	Else
+	{
+		[array]$xtags = @("<None>")
+	}
+
+	If($VM.other_config.Keys -contains "folder") #added by Webster
+	{
+		$folderName = $VM.Other_Config["folder"]
+	}
+	Else
+	{
+		$folderName = "<None>"
+	}
+
+	If ($MSWord -or $PDF)
+	{
+		If ($VMFirst -eq $False)
+		{
+			#Put the 2nd VM on, on a new page
+			$Selection.InsertNewPage()
+		}
+		
+		WriteWordLine 2 0 "VM: $($VM.name_label)"
+		WriteWordLIne 3 0 "General (Overview)"
+		[System.Collections.Hashtable[]] $ScriptInformation = @()
+		$ScriptInformation += @{ Data = "Name"; Value = $($VM.name_label); }
+		$ScriptInformation += @{ Data = "Description"; Value = $($VM.name_description); }
+		$ScriptInformation += @{ Data = "Tags"; Value = $($xtags -join ", "); }
+		$ScriptInformation += @{ Data = "Folder"; Value = $folderName; }
+		$ScriptInformation += @{ Data = "Operating System"; Value = $VMOSName; }
+		$ScriptInformation += @{ Data = "Virtualization mode"; Value = ""; }
+		$ScriptInformation += @{ Data = "BIOS strings copied"; Value = ""; }
+		$ScriptInformation += @{ Data = "Virtualization state"; Value = ""; }
+		$ScriptInformation += @{ Data = "Time since startup"; Value = ""; }
+		$ScriptInformation += @{ Data = "UUID"; Value = $($VM.uuid); }
+
+		$Table = AddWordTable -Hashtable $ScriptInformation `
+			-Columns Data, Value `
+			-List `
+			-Format $wdTableGrid `
+			-AutoFit $wdAutoFitFixed;
+
+		## IB - Set the header row format
+		SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
+
+		$Table.Columns.Item(1).Width = 150;
+		$Table.Columns.Item(2).Width = 250;
+
+		$Table.Rows.SetLeftIndent($Indent0TabStops, $wdAdjustProportional)
+
+		FindWordDocumentEnd
+		$Table = $Null
+		WriteWordLine 0 0 ""
+	}
+	If ($Text)
+	{
+		Line 1 "Name: " $($VM.name_label)
+		Line 2 "General (Overview)"
+		Line 3 "Description         : " $($VM.name_description)
+		Line 3 "Tags                : " "$($xtags -join ", ")"
+		Line 3 "Folder              : " $folderName
+		Line 3 "Operating System    : " $VMOSName
+		Line 3 "Virtualization mode : " ""
+		Line 3 "BIOS strings copied : " ""
+		Line 3 "Virtualization state: " ""
+		Line 3 "Time since startup  : " ""
+		Line 3 "UUID                : " $($VM.uuid)
+
+		Line 0 ""
+	}
+	If ($HTML)
+	{
+		$xtags = $xtags.Trim("<", ">")
+		$folderName = $folderName.Trim("<", ">")
+		WriteHTMLLine 2 0 "VM: $($VM.name_label)"
+		WriteHTMLLIne 3 0 "General (Overview)"
+		$rowdata = @()
+		$columnHeaders = @("Name", ($htmlsilver -bor $htmlbold), $($VM.name_label), $htmlwhite)
+		$rowdata += @(, ('Description', ($htmlsilver -bor $htmlbold), $($VM.name_description), $htmlwhite))
+		$rowdata += @(, ('Tags', ($htmlsilver -bor $htmlbold), "$($xtags -join ", ")", $htmlwhite))
+		$rowdata += @(, ('Folder', ($htmlsilver -bor $htmlbold), "$folderName", $htmlwhite))
+		$rowdata += @(, ('Operating System', ($htmlsilver -bor $htmlbold), $VMOSName, $htmlwhite))
+		$rowdata += @(, ("Virtualization mode", ($htmlsilver -bor $htmlbold), "", $htmlwhite))
+		$rowdata += @(, ("BIOS strings copied", ($htmlsilver -bor $htmlbold), "", $htmlwhite))
+		$rowdata += @(, ("Virtualization state", ($htmlsilver -bor $htmlbold), "", $htmlwhite))
+		$rowdata += @(, ("Time since startup", ($htmlsilver -bor $htmlbold), "", $htmlwhite))
+		$rowdata += @(, ("UUID", ($htmlsilver -bor $htmlbold), $($VM.uuid), $htmlwhite))
+
+		$msg = ""
+		$columnWidths = @("150", "250")
+		FormatHTMLTable $msg -rowArray $rowdata -columnArray $columnHeaders -fixedWidth $columnWidths
+		WriteHTMLLine 0 0 ""
+	}
+}
+
+Function OutputVMGeneralBootOptions
+{
+	Param([object] $VM)
+	Write-Verbose "$(Get-Date -Format G): `t`tOutput VM General Boot Options"
+
+	If ($MSWord -or $PDF)
+	{
+		WriteWordLine 3 0 "Boot Options"
+	}
+	If ($Text)
+	{
+		Line 2 "Boot Options"
+	}
+	If ($HTML)
+	{
+		WriteHTMLLine 3 0 "Boot Options"
+	}
+
+	$bootorder = $vm.HVM_boot_params["order"].Replace("c", "Disk;").Replace("d", "DVD-drive;").Replace("n", "Network;").TrimEnd(";").Split(";")
+	for ($c = 1 ; $c -le $bootorder.count ; $c++)
+	{
+		$bootorder[$c - 1] = "[$c] $($bootorder[$c-1])"
+	}
+
+	If($VM.HVM_boot_params.Keys -contains "firmware") #added by Webster
+	{
+		$BootMode = "$($VM.HVM_boot_params['firmware'].ToUpper()) Boot"
+	}
+	Else
+	{
+		$BootMode = "BIOS Boot" #assume BIOS Boot if the Key does not exist
+	}
+
+	If ($MSWord -or $PDF)
+	{
+		[System.Collections.Hashtable[]] $ScriptInformation = @()
+		$ScriptInformation += @{ Data = "Boot order"; Value = $($bootorder -join ", "); }
+		$ScriptInformation += @{ Data = "Boot mode"; Value = $BootMode; }
+
+		$Table = AddWordTable -Hashtable $ScriptInformation `
+			-Columns Data, Value `
+			-List `
+			-Format $wdTableGrid `
+			-AutoFit $wdAutoFitFixed;
+
+		## IB - Set the header row format
+		SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
+
+		$Table.Columns.Item(1).Width = 150;
+		$Table.Columns.Item(2).Width = 250;
+
+		$Table.Rows.SetLeftIndent($Indent0TabStops, $wdAdjustProportional)
+
+		FindWordDocumentEnd
+		$Table = $Null
+		WriteWordLine 0 0 ""
+	}
+	If ($Text)
+	{
+		Line 3 "Boot order: " $($bootorder -join ", ")
+		Line 3 "Boot mode : " $BootMode
+		Line 0 ""
+	}
+	If ($HTML)
+	{
+		$rowdata = @()
+		$columnHeaders = @("Boot order", ($htmlsilver -bor $htmlbold), $($bootorder -join ", "), $htmlwhite)
+		$rowdata += @(, ('Boot mode', ($htmlsilver -bor $htmlbold), $BootMode, $htmlwhite))
+
+		$msg = ""
+		$columnWidths = @("150", "250")
+		FormatHTMLTable $msg -rowArray $rowdata -columnArray $columnHeaders -fixedWidth $columnWidths
+		WriteHTMLLine 0 0 ""
+	}
+	
+}
+
+Function OutputVMGeneralCPU
+{
+	Param([object] $VM)
+	Write-Verbose "$(Get-Date -Format G): `t`tOutput VM General CPUs"
+
+	If ($MSWord -or $PDF)
+	{
+		WriteWordLine 3 0 "CPUs"
+	}
+	If ($Text)
+	{
+		Line 2 "CPUs"
+	}
+	If ($HTML)
+	{
+		WriteHTMLLine 3 0 "CPUs"
+	}
+	#from the XS team
+	#the topology is in the VM's platform property, key cores-per-socket
+	#VCPUs_at_startup	8
+	#VCPUs_max		8
+
+	If ($null -eq $($vm.platform["cores-per-socket"]))
+	{
+		$vCPUcoreText = "1 core"
+	}
+	ElseIf ($vm.platform["cores-per-socket"] -gt 1)
+	{
+		$vCPUcoreText = "$($vm.platform["cores-per-socket"]) cores"
+	}
+	Else
+	{
+		$vCPUcoreText = "$($vm.platform["cores-per-socket"]) core"
+	}
+
+	try
+	{
+		If($VM.platform.keys -contains "cores-per-socket") #added by Webster
+		{
+			$sockets = $([int]$VM.VCPUs_max / [int]$vm.platform["cores-per-socket"])
+		}
+		Else
+		{
+			$sockets = [int]$VM.VCPUs_max #assume that cores per socket is one if the Key does not exist
+		}
+		
+		If ($sockets -gt 1)
+		{
+			$vCPUText = "$sockets sockets with $vCPUcoreText each"
+		}
+		Else
+		{
+			$vCPUText = "$sockets socket with $vCPUcoreText"
+		}
+	}
+	catch
+	{
+		$vCPUText = "$($VM.VCPUs_max) ($vCPUcoreText per socket)"
+	}
+	
+	If ($MSWord -or $PDF)
+	{
+		[System.Collections.Hashtable[]] $ScriptInformation = @()
+		$ScriptInformation += @{ Data = "Virtual CPUs"; Value = "$($VM.VCPUs_max)"; }
+		$ScriptInformation += @{ Data = "Topology"; Value = $vCPUText; }
+
+		$Table = AddWordTable -Hashtable $ScriptInformation `
+			-Columns Data, Value `
+			-List `
+			-Format $wdTableGrid `
+			-AutoFit $wdAutoFitFixed;
+
+		## IB - Set the header row format
+		SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
+
+		$Table.Columns.Item(1).Width = 150;
+		$Table.Columns.Item(2).Width = 250;
+
+		$Table.Rows.SetLeftIndent($Indent0TabStops, $wdAdjustProportional)
+
+		FindWordDocumentEnd
+		$Table = $Null
+		WriteWordLine 0 0 ""
+	}
+	If ($Text)
+	{
+		Line 3 "Virtual CPUs: " "$($VM.VCPUs_max)"
+		Line 3 "Topology    : " $vCPUText
+		Line 0 ""
+	}
+	If ($HTML)
+	{
+		$rowdata = @()
+		$columnHeaders = @("Virtual CPUs", ($htmlsilver -bor $htmlbold), "$($VM.VCPUs_max)", $htmlwhite)
+		$rowdata += @(, ("Topology", ($htmlsilver -bor $htmlbold), $vCPUText, $htmlwhite))
+
+		$msg = ""
+		$columnWidths = @("150", "250")
+		FormatHTMLTable $msg -rowArray $rowdata -columnArray $columnHeaders -fixedWidth $columnWidths
+		WriteHTMLLIne 0 0 ""
+	}
+}
+
+Function OutputVMGeneralReadCaching
+{
+	Param([object] $VM)
+	Write-Verbose "$(Get-Date -Format G): `t`tOutput VM General Read Caching"
+
+	If ($MSWord -or $PDF)
+	{
+		WriteWordLine 3 0 "Read Caching"
+	}
+	If ($Text)
+	{
+		Line 2 "Read Caching"
+	}
+	If ($HTML)
+	{
+		WriteHTMLLine 3 0 "Read Caching"
+	}
+
+	#WEBSTER: The output text is hardcoded so I could see how wide to make the columns
+	#WEBSTER: I'll let JB handle getting this data
+	If ($MSWord -or $PDF)
+	{
+		[System.Collections.Hashtable[]] $ScriptInformation = @()
+		$ScriptInformation += @{ Data = "Status"; Value = "This VM is not using read caching"; }
+		$ScriptInformation += @{ Data = "Reason"; Value = "This VM does not have any read-only disks or disks with a read-only parent"; }
+
+		$Table = AddWordTable -Hashtable $ScriptInformation `
+			-Columns Data, Value `
+			-List `
+			-Format $wdTableGrid `
+			-AutoFit $wdAutoFitFixed;
+
+		## IB - Set the header row format
+		SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
+
+		$Table.Columns.Item(1).Width = 50;
+		$Table.Columns.Item(2).Width = 350;
+
+		$Table.Rows.SetLeftIndent($Indent0TabStops, $wdAdjustProportional)
+
+		FindWordDocumentEnd
+		$Table = $Null
+		WriteWordLine 0 0 ""
+	}
+	If ($Text)
+	{
+		Line 3 "Status: " "This VM is not using read caching"
+		Line 3 "Reason: " "This VM does not have any read-only disks or disks with a read-only parent"
+		Line 0 ""
+	}
+	If ($HTML)
+	{
+		$rowdata = @()
+		$columnHeaders = @("Status", ($htmlsilver -bor $htmlbold), "This VM is not using read caching", $htmlwhite)
+		$rowdata += @(, ("Reason", ($htmlsilver -bor $htmlbold), "This VM does not have any read-only disks or disks with a read-only parent", $htmlwhite))
+
+		$msg = ""
+		$columnWidths = @("50", "350")
+		FormatHTMLTable $msg -rowArray $rowdata -columnArray $columnHeaders -fixedWidth $columnWidths
+		WriteHTMLLIne 0 0 ""
+	}
+}
+
+Function OutputVMGeneral
 {
 	Param([object]$VM, [string]$VMOSName, [string]$VMHost, [bool]$VMFirst)
 	
 	Write-Verbose "$(Get-Date -Format G): `t`tOutput VM General"
-	If ($VMOSName -ne "Unknown")
+	<#If ($VMOSName -ne "Unknown")
 	{
 		#remove the pipe symbol from the $VMOSName variable
 		$pos = -1
@@ -12393,6 +12778,30 @@ Function OutputVM
 	{
 		$BootMode = "BIOS Boot" #assume BIOS Boot if the Key does not exist
 	}
+	#>
+	
+	[array]$xtags = @()
+	ForEach ($tag in $VM.tags)
+	{
+		$xtags += $tag
+	}
+	If ($xtags.count -gt 0)
+	{
+		[array]$xtags = $xtags | Sort-Object
+	}
+	Else
+	{
+		[array]$xtags = @("<None>")
+	}
+
+	If($VM.other_config.Keys -contains "folder") #added by Webster
+	{
+		$folderName = $VM.Other_Config["folder"]
+	}
+	Else
+	{
+		$folderName = "<None>"
+	}
 
 	If ($MSWord -or $PDF)
 	{
@@ -12402,27 +12811,12 @@ Function OutputVM
 			$Selection.InsertNewPage()
 		}
 		
-		WriteWordLine 2 0 "VM: $($VM.name_label)"
+		WriteWordLine 3 0 "General (Properties)"
 		[System.Collections.Hashtable[]] $ScriptInformation = @()
-		$ScriptInformation += @{ Data = "VM name"; Value = $($VM.name_label); }
-		$ScriptInformation += @{ Data = "Xen host name"; Value = $VMHost; }
-		$ScriptInformation += @{ Data = "VM Operating System"; Value = $VMOSName; }
-		$ScriptInformation += @{ Data = "Number of vCPUs"; Value = $VCPUText; }
-
-		If ($xenVMDynamicMemory)
-		{
-			$ScriptInformation += @{ Data = "Dynamic Memory"; Value = "True (DEPRECATED!)"; }
-			$ScriptInformation += @{ Data = "Minimum Memory"; Value = $xenVmMemMin; }
-			$ScriptInformation += @{ Data = "Maximum Memory"; Value = $xenVmMemMax; }
-		}
-		Else
-		{
-			$ScriptInformation += @{ Data = "Memory"; Value = $xenVmMem; }
-		}
-		$ScriptInformation += @{ Data = "Boot order"; Value = $($bootorder -join ", "); }
-		#$ScriptInformation += @{ Data = "Boot mode"; Value = $VM.HVM_boot_params["firmware"].ToUpper(); }
-		$ScriptInformation += @{ Data = "Boot mode"; Value = $BootMode; }
-		$ScriptInformation += @{ Data = "Secure boot"; Value = $xenVMSecureBoot; }
+		$ScriptInformation += @{ Data = "Name"; Value = $($VM.name_label); }
+		$ScriptInformation += @{ Data = "Description"; Value = $($VM.name_description); }
+		$ScriptInformation += @{ Data = "Folder"; Value = $folderName; }
+		$ScriptInformation += @{ Data = "Tags"; Value = $($xtags -join ", "); }
 
 		$Table = AddWordTable -Hashtable $ScriptInformation `
 			-Columns Data, Value `
@@ -12444,51 +12838,23 @@ Function OutputVM
 	}
 	If ($Text)
 	{
-		Line 1 "VM name: " $($VM.name_label)
-		Line 2 "Xen host name`t`t: " $VMHost
-		Line 2 "VM Operating System`t: " $VMOSName
-		Line 2 "Number of vCPUs`t`t: " $VCPUText
-
-		If ($xenVMDynamicMemory)
-		{
-			Line 2 "Dynamic Memory`t`t: " "True (DEPRECATED!)"
-			Line 2 "Minimum Memory`t`t: " $xenVmMemMin
-			Line 2 "Maximum Memory`t`t: " $xenVmMemMax
-		}
-		Else
-		{
-			Line 2 "Memory`t`t`t: " $xenVmMem
-		}
-		Line 2 "Boot order`t`t: " $($bootorder -join ", ")
-		#Line 2 "Boot mode`t`t: " $VM.HVM_boot_params["firmware"].ToUpper()
-		Line 2 "Boot mode`t`t: " $BootMode
-		Line 2 "Secure boot`t`t: " $xenVMSecureBoot
-
+		Line 2 "General (Properties)"
+		Line 3 "Name       : " $($VM.name_label)
+		Line 3 "Description: " $($VM.name_description)
+		Line 3 "Folder     : " $folderName
+		Line 3 "Tags       : " "$($xtags -join ", ")"
 		Line 0 ""
 	}
 	If ($HTML)
 	{
-		WriteHTMLLine 2 0 "VM: $($VM.name_label)"
+		$xtags = $xtags.Trim("<", ">")
+		$folderName = $folderName.Trim("<", ">")
+		WriteHTMLLine 3 0 "General (Properties)"
 		$rowdata = @()
-		$columnHeaders = @("VM name", ($htmlsilver -bor $htmlbold), $($VM.name_label), $htmlwhite)
-		$rowdata += @(, ('Xen host name', ($htmlsilver -bor $htmlbold), $VMHost, $htmlwhite))
-		$rowdata += @(, ('VM Operating System', ($htmlsilver -bor $htmlbold), $VMOSName, $htmlwhite))
-		$rowdata += @(, ('Number of vCPUs', ($htmlsilver -bor $htmlbold), $VCPUText, $htmlwhite))
-
-		If ($xenVMDynamicMemory)
-		{
-			$rowdata += @(, ('Dynamic Memory', ($htmlsilver -bor $htmlbold), "True (DEPRECATED!)", $htmlwhite))
-			$rowdata += @(, ('Minimum Memory', ($htmlsilver -bor $htmlbold), $xenVmMemMin, $htmlwhite))
-			$rowdata += @(, ('Maximum Memory', ($htmlsilver -bor $htmlbold), $xenVmMemMax, $htmlwhite))
-		}
-		Else
-		{
-			$rowdata += @(, ('Memory', ($htmlsilver -bor $htmlbold), $xenVmMem, $htmlwhite))
-		}
-		$rowdata += @(, ('Boot order', ($htmlsilver -bor $htmlbold), $($bootorder -join ", "), $htmlwhite))
-		#$rowdata += @(, ('Boot mode', ($htmlsilver -bor $htmlbold), $VM.HVM_boot_params["firmware"].ToUpper(), $htmlwhite))
-		$rowdata += @(, ('Boot mode', ($htmlsilver -bor $htmlbold), $BootMode, $htmlwhite))
-		$rowdata += @(, ('Secure boot', ($htmlsilver -bor $htmlbold), $xenVMSecureBoot, $htmlwhite))
+		$columnHeaders = @("Name", ($htmlsilver -bor $htmlbold), $($VM.name_label), $htmlwhite)
+		$rowdata += @(, ('Description', ($htmlsilver -bor $htmlbold), $($VM.name_description), $htmlwhite))
+		$rowdata += @(, ('Folder', ($htmlsilver -bor $htmlbold), "$folderName", $htmlwhite))
+		$rowdata += @(, ('Tags', ($htmlsilver -bor $htmlbold), "$($xtags -join ", ")", $htmlwhite))
 
 		$msg = ""
 		$columnWidths = @("150", "250")
@@ -12749,7 +13115,7 @@ Function OutputVMCPU
 		SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 		$Table.Columns.Item(1).Width = 200;
-		$Table.Columns.Item(2).Width = 150;
+		$Table.Columns.Item(2).Width = 200;
 
 		$Table.Rows.SetLeftIndent($Indent0TabStops, $wdAdjustProportional)
 
@@ -14016,7 +14382,7 @@ Function OutputVMNIC
 		}
 		If ($Text)
 		{
-			Line 3 "Number of NICs`t`t: " "$nrVIFs"
+			Line 3 "Number of NICs: " "$nrVIFs"
 			Line 0 ""
 		}
 		If ($HTML)
@@ -14038,11 +14404,11 @@ Function OutputVMNIC
 			If ($Text)
 			{
 				Line 3 "Device: " "$($Item.device)"
-				Line 4 "MAC address`t`t: " "$($Item.MAC)"
-				Line 4 "MAC autogenerated`t: " "$($Item.MACautogenerated)"
-				Line 4 "Limit`t`t`t: " "$($Item.limit)"
-				Line 4 "IP Address`t`t: " "$($Item.IPAddress)"
-				Line 4 "Active`t`t`t: " "$($Item.Active)"
+				Line 4 "MAC address      : " "$($Item.MAC)"
+				Line 4 "MAC autogenerated: " "$($Item.MACautogenerated)"
+				Line 4 "Limit            : " "$($Item.limit)"
+				Line 4 "IP Address       : " "$($Item.IPAddress)"
+				Line 4 "Active           : " "$($Item.Active)"
 			}
 			If ($HTML)
 			{
@@ -14351,7 +14717,6 @@ Function OutputVMSnapshots
 		}
 	}
 }
-
 #endregion VMs
 
 #region script core
@@ -14372,14 +14737,7 @@ Else
 	SetFileNames "$($Script:XSPool.name_label)"
 }
 
-If ($Null -eq $Script:XSPool.name_label)
-{
-	[string]$Script:Title = "Inventory Report for the XenServer Host: $($Script:XSHosts[0].hostname)"
-}
-Else
-{
-	[string]$Script:Title = "Inventory Report for the XenServer Pool: $($Script:XSPool.name_label)"
-}
+#[string]$Script:Title = "Inventory Report for the XenServer Pool: $($Script:XSPool.name_label)"
 
 Write-Verbose "$(Get-Date -Format G): Start writing report data"
 

--- a/XS_Inventory_V1_ReadMe.rtf
+++ b/XS_Inventory_V1_ReadMe.rtf
@@ -1,7 +1,7 @@
 {\rtf1\adeflang1025\ansi\ansicpg1252\uc1\adeff0\deff0\stshfdbch31505\stshfloch31506\stshfhich31506\stshfbi0\deflang1033\deflangfe1033\themelang1033\themelangfe0\themelangcs0{\fonttbl{\f0\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f2\fbidi \fmodern\fcharset0\fprq1{\*\panose 02070309020205020404}Courier New;}
 {\f3\fbidi \froman\fcharset2\fprq2{\*\panose 05050102010706020507}Symbol;}{\f10\fbidi \fnil\fcharset2\fprq2{\*\panose 05000000000000000000}Wingdings;}{\f34\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria Math;}
-{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
-{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}
+{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
+{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}
 {\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\flominor\f31504\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\fdbminor\f31505\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhiminor\f31506\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}
 {\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f44\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\f45\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
@@ -111,21 +111,22 @@ Header Char;}{\s23\ql \li0\ri0\nowidctlpar\tqc\tx4680\tqr\tx9360\wrapdefault\faa
 \levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li6480\lin6480 }{\listname ;}\listid1955283310}}{\*\listoverridetable{\listoverride\listid1955283310\listoverridecount0\ls1}{\listoverride\listid1818835589
 \listoverridecount0\ls2}{\listoverride\listid319386001\listoverridecount0\ls3}{\listoverride\listid1259829870\listoverridecount0\ls4}{\listoverride\listid747194388\listoverridecount0\ls5}{\listoverride\listid264927731\listoverridecount0\ls6}
 {\listoverride\listid1694726244\listoverridecount0\ls7}}{\*\pgptbl {\pgp\ipgp0\itap0\li0\ri0\sb0\sa0}}{\*\rsidtbl \rsid219208\rsid677819\rsid995078\rsid1012917\rsid1602598\rsid2181327\rsid2579094\rsid2584542\rsid2978753\rsid3344576\rsid3426073\rsid3496162
-\rsid3678897\rsid3761251\rsid3830441\rsid4063807\rsid4412263\rsid4667061\rsid4788357\rsid5267713\rsid6041144\rsid6104541\rsid6258287\rsid6520475\rsid8068250\rsid8410782\rsid8478496\rsid8676188\rsid9111200\rsid9112866\rsid9467414\rsid9528706\rsid9703780
-\rsid9729535\rsid9986361\rsid11281155\rsid11287022\rsid11480840\rsid11488686\rsid11696173\rsid11731749\rsid12013473\rsid12215775\rsid12585615\rsid12801149\rsid13120733\rsid13513834\rsid13593745\rsid13844203\rsid13853169\rsid13987238\rsid14095752
-\rsid14245117\rsid14697282\rsid14881286\rsid14966414\rsid15666087\rsid16078565\rsid16349588\rsid16395009\rsid16517051\rsid16597410\rsid16673813}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440
-\mintLim0\mnaryLim1}{\info{\operator Carl Webster}{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2023\mo8\dy15\hr6\min8}{\version40}{\edmins283}{\nofpages19}{\nofwords4610}{\nofchars26280}{\nofcharsws30829}{\vern77}}{\*\userprops {\propname GrammarlyDocum
-entId}\proptype30{\staticval 3fd2975cd99c5b9cf68f62fa6d88418f1aab9454bf804457ab26ef3f30daedff}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
+\rsid3678897\rsid3761251\rsid3830441\rsid4063807\rsid4412263\rsid4667061\rsid4788357\rsid5267713\rsid6041144\rsid6104541\rsid6258287\rsid6520475\rsid7481205\rsid8068250\rsid8410782\rsid8478496\rsid8676188\rsid9111200\rsid9112866\rsid9467414\rsid9528706
+\rsid9703780\rsid9729535\rsid9986361\rsid10421168\rsid11281155\rsid11287022\rsid11480840\rsid11488686\rsid11696173\rsid11731749\rsid12013473\rsid12215775\rsid12585615\rsid12801149\rsid13120733\rsid13513834\rsid13593745\rsid13844203\rsid13853169
+\rsid13987238\rsid14095752\rsid14245117\rsid14697282\rsid14881286\rsid14966414\rsid15666087\rsid16078565\rsid16349588\rsid16395009\rsid16517051\rsid16597410\rsid16673813}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0
+\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Carl Webster}{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2023\mo8\dy20\hr1\min23}{\version41}{\edmins283}{\nofpages19}{\nofwords4610}{\nofchars26280}{\nofcharsws30829}{\vern77}}{\*\userprops 
+{\propname GrammarlyDocumentId}\proptype30{\staticval 3fd2975cd99c5b9cf68f62fa6d88418f1aab9454bf804457ab26ef3f30daedff}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}
+\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
 \widowctrl\ftnbj\aenddoc\trackmoves0\trackformatting1\donotembedsysfont0\relyonvml0\donotembedlingdata1\grfdocevents0\validatexml0\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors0\horzdoc\dghspace120\dgvspace120\dghorigin1701
 \dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale111\rsidroot11488686 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
-{\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0MbCwsDA0MzcytjQwNjBS0lEKTi0uzszPAykwMq0FAM21dPQtAAAA}}{\*\ftnsep \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid15666087 \rtlch\fcs1 
-\af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid14095752 \chftnsep 
+{\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0MbCwsDA0MzcytjQwNjBS0lEKTi0uzszPAykwMqsFAA7mWd8tAAAA}}{\*\ftnsep \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid15666087 \rtlch\fcs1 
+\af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid10421168 \chftnsep 
 \par }}{\*\ftnsepc \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid15666087 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
-\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid14095752 \chftnsepc 
+\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid10421168 \chftnsepc 
 \par }}{\*\aftnsep \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid15666087 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
-\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid14095752 \chftnsep 
+\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid10421168 \chftnsep 
 \par }}{\*\aftnsepc \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid15666087 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
-\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid14095752 \chftnsepc 
+\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid10421168 \chftnsepc 
 \par }}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\headerl \ltrpar \pard\plain \ltrpar\s21\ql \li0\ri0\nowidctlpar\tqc\tx4680\tqr\tx9360\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid15666087 
 \par }}{\headerr \ltrpar \pard\plain \ltrpar\s21\ql \li0\ri0\nowidctlpar\tqc\tx4680\tqr\tx9360\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
@@ -327,7 +328,7 @@ Before using PowerShell to document anything in a Xen}{\rtlch\fcs1 \af37\afs22 \
 {\field\flddirty{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\lang1024\langfe1024\noproof\insrsid12013473\charrsid16349588 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "http://Citrix.com" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\lang1024\langfe1024\noproof\insrsid11731749\charrsid16349588 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b3e00000068007400740070003a002f002f006300690074007200690078002e0063006f006d002f000000795881f43b1d7f48af2c825dc485276300000000a5ab0000000000000050efb1711c023300d0736400480165
-004000c5cd0000}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf2\lang1024\langfe1024\noproof\insrsid12013473\charrsid16349588 \hich\af37\dbch\af31505\loch\f37 http://Citrix.com}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
+004000c5cd00007b}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf2\lang1024\langfe1024\noproof\insrsid12013473\charrsid16349588 \hich\af37\dbch\af31505\loch\f37 http://Citrix.com}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\lang1024\langfe1024\noproof\insrsid12013473\charrsid16349588 \hich\af37\dbch\af31505\loch\f37  ,}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12013473 
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f2\fs22\lang1024\langfe1024\noproof\insrsid12013473\charrsid16349588 \hich\af2\dbch\af31505\loch\f2 o\tab}}\pard \ltrpar\ql \fi-360\li1440\ri0\sa200\sl276\slmult1
 \nowidctlpar\wrapdefault\faauto\ls4\ilvl1\rin0\lin1440\itap0\pararsid8478496 {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\lang1024\langfe1024\noproof\insrsid12013473\charrsid16349588 \hich\af37\dbch\af31505\loch\f37 Log}{\rtlch\fcs1 \af37\afs22 
@@ -358,8 +359,8 @@ Before using PowerShell to document anything in a Xen}{\rtlch\fcs1 \af37\afs22 \
 \f37\fs22\insrsid13844203 \hich\af37\dbch\af31505\loch\f37  }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid13844203\charrsid11731749 \hich\af37\dbch\af31505\loch\f37 SDK (Software Development Kit) }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \i\f37\fs22\insrsid13593745 \hich\af37\dbch\af31505\loch\f37 8.2.3}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13844203 ,
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f2\fs22\insrsid13844203 \hich\af2\dbch\af31505\loch\f2 o\tab}\hich\af37\dbch\af31505\loch\f37 Download the }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13593745\charrsid13593745 
-\hich\af37\dbch\af31505\loch\f37 CitrixHypervisor-8.2.3-SDK.zip}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11731749 \hich\af37\dbch\af31505\loch\f37  }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13844203 
-\hich\af37\dbch\af31505\loch\f37 file to your downloads folder,
+\hich\af37\dbch\af31505\loch\f37 CitrixHyp\hich\af37\dbch\af31505\loch\f37 ervisor-8.2.3-SDK.zip}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11731749 \hich\af37\dbch\af31505\loch\f37  }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+\f37\fs22\insrsid13844203 \hich\af37\dbch\af31505\loch\f37 file to your downloads folder,
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f2\fs22\insrsid13844203 \hich\af2\dbch\af31505\loch\f2 o\tab}\hich\af37\dbch\af31505\loch\f37 Extract the }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13593745\charrsid13593745 
 \hich\af37\dbch\af31505\loch\f37 CitrixHypervisor-8.2.3-SDK.zip}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13844203 \hich\af37\dbch\af31505\loch\f37 file,
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f2\fs22\insrsid995078 \hich\af2\dbch\af31505\loch\f2 o\tab}}\pard \ltrpar\ql \fi-360\li1440\ri0\sa200\sl276\slmult1
@@ -965,11 +966,11 @@ XS_Inventory.ps1 -ServerName <String> [-User <String>] [-HTML] [-Text] }{\rtlch\
 \par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (}{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9528706 \hich\af2\dbch\af31505\loch\f2 HYPERLIN\hich\af2\dbch\af31505\loch\f2 
 K "https://go.microsoft.com/fwlink/?LinkID=113216"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9528706 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b76000000680074007400700073003a002f002f0067006f002e006d006900630072006f0073006f00660074002e0063006f006d002f00660077006c0069006e006b002f003f004c0069006e006b00490044003d003100
-310033003200310036000000795881f43b1d7f48af2c825dc485276300000000a5ab000300000000003200}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid9528706\charrsid9528706 \hich\af2\dbch\af31505\loch\f2 
+310033003200310036000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000000000320064}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid9528706\charrsid9528706 \hich\af2\dbch\af31505\loch\f2 
 https:/go.microsoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9528706\charrsid9528706 \hich\af2\dbch\af31505\loch\f2 ).
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 INPUTS
-\par \hich\af2\dbch\af31505\loch\f2     None.  You cannot pipe \hich\af2\dbch\af31505\loch\f2 objects to this script.
+\par \hich\af2\dbch\af31505\loch\f2     None.  You cannot pipe\hich\af2\dbch\af31505\loch\f2  objects to this script.
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 OUTPUTS
@@ -981,11 +982,11 @@ https:/go.microsoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefau
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         NAME: XS_Inventory.ps1
-\par \hich\af2\dbch\af31505\loch\f2         VERSION: 0.0}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13513834 \hich\af2\dbch\af31505\loch\f2 2}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14245117 \hich\af2\dbch\af31505\loch\f2 4}{\rtlch\fcs1 
+\par \hich\af2\dbch\af31505\loch\f2         VERSION: 0.0}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13513834 \hich\af2\dbch\af31505\loch\f2 2}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7481205 \hich\af2\dbch\af31505\loch\f2 5}{\rtlch\fcs1 
 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9528706\charrsid9528706 
-\par \hich\af2\dbch\af31505\loch\f2         AUTHOR: Carl Webster and John Billekens}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13513834 ,}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9528706\charrsid9528706 \hich\af2\dbch\af31505\loch\f2 
- along with help from Michael B. Smith, Guy Leech, and the XenServer team
-\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16078565 \hich\af2\dbch\af31505\loch\f2 August 1}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14245117 \hich\af2\dbch\af31505\loch\f2 5}{
+\par \hich\af2\dbch\af31505\loch\f2         AUTHOR: Carl Webster and John Billeken\hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13513834 ,}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9528706\charrsid9528706 
+\hich\af2\dbch\af31505\loch\f2  along with help from Michael B. Smith, Guy Leech, and the XenServer team
+\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16078565 \hich\af2\dbch\af31505\loch\f2 August }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7481205 \hich\af2\dbch\af31505\loch\f2 20}{
 \rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9528706\charrsid9528706 \hich\af2\dbch\af31505\loch\f2 , 2023
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 1 --------------------------
@@ -993,7 +994,7 @@ https:/go.microsoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefau
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XS_Inventory.ps1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Outputs, by default, to HTML.
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  Prompts for the XenServer Pool and login credentials.
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   Prompts for the XenServer Pool and login credentials.
 \par 
 \par 
 \par 
@@ -1060,7 +1061,7 @@ https:/go.microsoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefau
 \par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9528706 \hich\af2\dbch\af31505\loch\f2 HYPERLINK "mailto:}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9528706\charrsid9528706 
 \hich\af2\dbch\af31505\loch\f2 SuperSleuth@SherlockHolmes.com}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9528706 \hich\af2\dbch\af31505\loch\f2 "}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13513834 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b640000006d00610069006c0074006f003a005300750070006500720053006c006500750074006800400053006800650072006c006f0063006b0048006f006c006d00650073002e0063006f006d000000795881f43b1d
-7f48af2c825dc485276300000000a5ab00030fddae000045}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid9528706\charrsid9111200 \hich\af2\dbch\af31505\loch\f2 SuperSleuth@SherlockHolmes.com}}}\sectd \ltrsect
+7f48af2c825dc485276300000000a5ab00030fddae00004500}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid9528706\charrsid9111200 \hich\af2\dbch\af31505\loch\f2 SuperSleuth@SherlockHolmes.com}}}\sectd \ltrsect
 \linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9528706 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9528706\charrsid9528706 \hich\af2\dbch\af31505\loch\f2 -PDF
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Uses:
@@ -1169,17 +1170,17 @@ https:/go.microsoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefau
 \par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9528706 \hich\af2\dbch\af31505\loch\f2 HYPERLINK "https://support.google.com/a/answer/2956491?hl=en"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid9528706 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7c000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0032003900350036003400
-390031003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab0003d90098f9000000}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid9528706\charrsid9528706 \hich\af2\dbch\af31505\loch\f2 
+390031003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab0003d90098f900000036}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid9528706\charrsid9528706 \hich\af2\dbch\af31505\loch\f2 
 https://support.google.com/a/answer/2956491?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9528706\charrsid9528706 
 \par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9528706 \hich\af2\dbch\af31505\loch\f2 HYPERLINK "https://support.google.com/a/answer/176600?hl=en"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid9528706 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7a000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0031003700360036003000
-30003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab00030061c00000fd00}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid9528706\charrsid9528706 \hich\af2\dbch\af31505\loch\f2 
+30003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab00030061c00000fd0072}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid9528706\charrsid9528706 \hich\af2\dbch\af31505\loch\f2 
 https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9528706\charrsid9528706 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     To send an email using a Gmail or }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9528706 \hich\af2\dbch\af31505\loch\f2 G-suite}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9528706\charrsid9528706 
 \hich\af2\dbch\af31505\loch\f2  account, you may have to turn ON the "Less
-\par \hich\af2\dbch\af31505\loch\f2     secure app access" option on your account.
+\par \hich\af2\dbch\af31505\loch\f2     secure app access" option on your accou\hich\af2\dbch\af31505\loch\f2 nt.
 \par \hich\af2\dbch\af31505\loch\f2     ***GMAIL/G SUITE SMTP RELAY***
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script generates an anonymous, secure password for the anonymous@domain.tld
@@ -1202,15 +1203,15 @@ https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\sectde
 HYPERLINK "https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-office-3"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9528706 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b40010000680074007400700073003a002f002f0064006f00630073002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f00650078006300680061006e0067006500
 2f006d00610069006c002d0066006c006f0077002d0062006500730074002d007000720061006300740069006300650073002f0068006f0077002d0074006f002d007300650074002d00750070002d0061002d006d0075006c0074006900660075006e006300740069006f006e002d006400650076006900630065002d006f
-0072002d006100700070006c00690063006100740069006f006e002d0074006f002d00730065006e0064002d0065006d00610069006c002d007500730069006e0067002d006f00660066006900630065002d0033000000795881f43b1d7f48af2c825dc485276300000000a5ab00037f0000d0a55000}}}{\fldrslt {
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid9528706\charrsid9528706 \hich\af2\dbch\af31505\loch\f2 https://docs.microsoft.com/en-us/exchange\hich\af2\dbch\af31505\loch\f2 
-/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-office-3}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9528706\charrsid9528706 
+0072002d006100700070006c00690063006100740069006f006e002d0074006f002d00730065006e0064002d0065006d00610069006c002d007500730069006e0067002d006f00660066006900630065002d0033000000795881f43b1d7f48af2c825dc485276300000000a5ab00037f0000d0a5500075}}}{\fldrslt {
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid9528706\charrsid9528706 \hich\af2\dbch\af31505\loch\f2 https://docs.microsoft.com/en-us/exchang\hich\af2\dbch\af31505\loch\f2 
+e/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-office-3}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9528706\charrsid9528706 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     This uses Option 2 from the above link.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ***OFFICE 365 Example***
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script uses the email server labaddomain-com.mail.protection.o\hich\af2\dbch\af31505\loch\f2 utlook.com, sending
+\par \hich\af2\dbch\af31505\loch\f2     The script uses the email server labaddomain-com.mail.protection.\hich\af2\dbch\af31505\loch\f2 outlook.com, sending
 \par \hich\af2\dbch\af31505\loch\f2     from SomeEmailAddress@labaddomain.com and sending to ITGroupDL@labaddomain.com.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script uses the default SMTP port 25 and SSL.
@@ -1226,11 +1227,11 @@ HYPERLINK "https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/ho
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XS_Inventory.ps1 -SmtpServer smtp.office365.com -SmtpPort 587
 \par \hich\af2\dbch\af31505\loch\f2     -UseSSL -From Webster@CarlWebster.com -To ITGroup@CarlWebster.com
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script uses the email \hich\af2\dbch\af31505\loch\f2 server smtp.office365.com on port 587 using SSL, sending from
+\par \hich\af2\dbch\af31505\loch\f2     The script uses the email\hich\af2\dbch\af31505\loch\f2  server smtp.office365.com on port 587 using SSL, sending from
 \par \hich\af2\dbch\af31505\loch\f2     webster@carlwebster.com and sending to ITGroup@carlwebster.com.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send an email, the script prompts
-\par \hich\af2\dbch\af31505\loch\f2     the user to enter valid credenti\hich\af2\dbch\af31505\loch\f2 als.
+\par \hich\af2\dbch\af31505\loch\f2     the user to enter valid credent\hich\af2\dbch\af31505\loch\f2 ials.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Outputs, by default, to HTML.
 \par \hich\af2\dbch\af31505\loch\f2     Prompts for the XenServer Pool and login credentials.
@@ -1241,7 +1242,7 @@ HYPERLINK "https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/ho
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 14 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XS_Inventory.ps1 -SmtpServer smtp.gmail.com -SmtpPort 587
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2 -UseSSL -From Webster@CarlWebster.com -To ITGroup@CarlWebster.com
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  -UseSSL -From Webster@CarlWebster.com -To ITGroup@CarlWebster.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     *** NOTE ***
 \par \hich\af2\dbch\af31505\loch\f2     To send an email using a Gmail or G-suite account, you may have to turn ON the "Less
@@ -1377,8 +1378,8 @@ fffffffffffffffffdfffffffeffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e50000000000000000000000005035
-8bd168cfd901feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
+ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e5000000000000000000000000e000
+37d82ed3d901feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000
 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff000000000000000000000000000000000000000000000000
 0000000000000000000000000000000000000000000000000105000000000000}}


### PR DESCRIPTION
#.025
#	Added some missing section headings in the host output
#	Copied Function OutputVM to OutputVMGeneralOverview
#		Altered Function OutputVMGeneralOverview data to match VM General Properties, General
#	Copied Function OutputVMBootOptions to OutputVMGeneralBootOptions
#		Altered Function OutputVMGeneralBootOptions data to match VM General Properties, Boot Options
#	Copied Function OutputVMCPU to OutputVMGeneralCPU
#		Altered Function OutputVMGeneralCPU data to match VM General Properties, CPUs
#	Create stub holder Function OutputVMGeneralReadCaching
#	Fixed the report title for Word/PDF output
#	For Pool, Host, and VM General output headings, add "General (Overview)" and "General (Properties)"
#	Renamed Function OutputVM to OutputVMGeneral
#	Reordered the VM functions to match the output order in the console
